### PR TITLE
Fixed localization for "No Items Defined" message

### DIFF
--- a/VSIX/CSharp-DAL2-MVC-Template/Views/Item/Index.cshtml
+++ b/VSIX/CSharp-DAL2-MVC-Template/Views/Item/Index.cshtml
@@ -7,7 +7,7 @@
 <div id="Items-@Dnn.ModuleContext.ModuleId">
     @if (Model.Count() == 0)
     {
-        <p>@Dnn.LocalizeString("NoItemsDefined")</p>
+        <p>@Dnn.LocalizeString("NoItems")</p>
     }
     else
     {


### PR DESCRIPTION
It's a bit confusing for newcomers to not see a thing after following the install instructions.
